### PR TITLE
Add tags to posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,6 +6,14 @@ layout: default
     <header class="post-header">
       <h1 class="post-title" itemprop="name headline">{{ page.title | escape }}</h1>
       <p class="post-meta"><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%b %-d, %Y" }}</time>{% if page.author %} • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>{% endif %}</p>
+      {% for tag in page.tags %}
+      <a href="/blog/tags/#{{ tag }}">
+        <div class="chip">
+          <i class="close material-icons">local_offer</i>
+          {{ tag }}
+        </div>
+      </a>
+      {% endfor %}
     </header>
 
     <div class="post-content" itemprop="articleBody">

--- a/_posts/2017-06-15-hello-world-predictive-healthcare.md
+++ b/_posts/2017-06-15-hello-world-predictive-healthcare.md
@@ -5,6 +5,7 @@ author: Mike Draugelis
 date:   2017-06-15 10:59:56 -0500
 comments: true
 categories: healthcare
+tags: [healthcare]
 ---
 In 2014, we started our work at Penn Medicine with one simple goal: to make our patients' lives better, and to create a more efficient health system.
 

--- a/blog/tags.html
+++ b/blog/tags.html
@@ -1,0 +1,67 @@
+---
+layout: default
+title: Tag
+---
+
+<div class="container">
+    {% comment %}
+    Extracts all the tags from your posts and sort tags.
+    {% endcomment %}
+    {% assign rawtags = "" %}
+    {% for post in site.posts %}
+        {% assign ttags = post.tags | join:'|' | append:'|' %}
+        {% assign rawtags = rawtags | append:ttags %}
+    {% endfor %}
+    {% assign rawtags = rawtags | split:'|' | sort %}
+
+    {% comment %}
+    Removes dulpicated tags and blank tags.
+    {% endcomment %}
+    {% assign tags = "" %}
+    {% for tag in rawtags %}
+        {% if tag != "" %}
+            {% if tags == "" %}
+                {% assign tags = tag | split:'|' %}
+            {% endif %}
+            {% unless tags contains tag %}
+                {% assign tags = tags | join:'|' | append:'|' | append:tag | split:'|' %}
+            {% endunless %}
+        {% endif %}
+    {% endfor %}
+
+    {% comment %}
+    List all the tags you have in the blog.
+    {% endcomment %}
+    <div class="card-panel grey lighten-4">
+    {% for tag in tags %}
+        <a href="#{{ tag | slugify }}">
+          <div class="chip">
+            <i class="close material-icons">local_offer</i>
+            {{ tag }}
+          </div>
+        </a>
+    {% endfor %}
+    </div>
+    <br>
+    <div>
+    {% comment %}
+    List all your posts posted with a certain tag.
+    {% endcomment %}
+    {% for tag in tags %}
+        <ul>
+        <h4 id="{{ tag | slugify }}">{{ tag }}</h4>
+        {% for post in site.posts %}
+            <li>
+            {% if post.tags contains tag %}
+                <a href="{{ post.url }}">
+                {{ post.title }}<br>
+                </a>
+                <small>{{ post.date | date_to_string }}</small>
+            {% endif %}
+            </li>
+        {% endfor %}
+        </ul>
+    {% endfor %}
+    </div>
+    <br>
+</div>


### PR DESCRIPTION
No Verification steps.

This branch adds a template that aggregates all tags on the site and renders them at `/blog/tags` with anchor links. It also adds tags to individual posts with link to corresponding section under tags page:
<img width="913" alt="screen shot 2017-08-22 at 11 09 51 am" src="https://user-images.githubusercontent.com/987473/29572481-7694eaa6-872a-11e7-9b72-3cba5e53dbee.png">
