### PR TITLE
Add LaTex to PNG rendering support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jekyll/jekyll
+FROM jekyll/jekyll:3.4.0
 COPY . /srv/jekyll
 WORKDIR /srv/jekyll
 ENTRYPOINT [ "jekyll" ]

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
-ruby '2.3.3'
 
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,8 +59,5 @@ DEPENDENCIES
   rack-jekyll
   tzinfo-data
 
-RUBY VERSION
-   ruby 2.3.3p222
-
 BUNDLED WITH
-   1.15.2
+   1.15.4

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,6 +16,7 @@
     <script src="/assets/js/materialize.js"></script>
     <script src="/assets/js/jquery.matchHeight.js"></script>
     <script src="/assets/js/init.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
   </body>
 
 </html>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -19,6 +19,9 @@ body{
 .strong{
 	font-weight: bold;
 }
+strong{
+	font-weight: 700;
+}
 .icon-block {
   padding: 0 15px;
 }
@@ -50,7 +53,12 @@ h5 {
 h6 {
   font-size: 1rem;
 }
-
+.container ul {
+	margin: 0 0 0 20px;
+	li{
+		list-style-type: disc;
+	}
+}
 .top-nav{
 	background: #0d47a1;
 	overflow: hidden;


### PR DESCRIPTION
This PR adds MathJax library to the template to support Latex to PNG rendering on posts. The new Jekyll image is using jekyll 3.6 which has incompatibility issues with some of the gems. In this PR the base image is set to 3.4.0 to avoid any of the incompatibilities. 
Verification steps:
```
docker-compose up
```
Add a mathematical notation using LaTex notation indicated by the $ (inline) or $$ tags, and it should render as below:
![screenshot](https://user-images.githubusercontent.com/987473/32419342-6648d8f4-c246-11e7-9384-8c35123e1fbf.png)

Closes #19 