### PR TITLE
Fix broken link in mobile nav

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -38,7 +38,7 @@
         <li><a href="/about">About</a></li>
         <li><a href="/projects/sepsis">Early Warning System</a></li>
         <li><a href="/projects/heart">CHF Wired</a></li>
-        <li><a href="/organization/team">Team</a></li>
+        <li><a href="/team">Team</a></li>
         <li><a href="/blog">Blog</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>


### PR DESCRIPTION
The link for team page in mobile nav was incorrect, and this PR fixes it.

No verification steps.